### PR TITLE
update element mixin to update element coordinates on every scroll

### DIFF
--- a/modules/mixins/Helpers.js
+++ b/modules/mixins/Helpers.js
@@ -67,12 +67,11 @@ var Helpers = {
 
           if(!element) {
               element = scroller.get(to);
-
-              var cords = element.getBoundingClientRect();
-              elemTopBound = (cords.top + y);
-              elemBottomBound = elemTopBound + cords.height;
           }
 
+          var cords = element.getBoundingClientRect();
+          elemTopBound = (cords.top + y);
+          elemBottomBound = elemTopBound + cords.height;
           var offsetY = y - this.props.offset;
           var isInside = (offsetY >= elemTopBound && offsetY <= elemBottomBound);
           var isOutside = (offsetY < elemTopBound || offsetY > elemBottomBound);


### PR DESCRIPTION
The coordinates of the elements that are used to determine which link to highlight are calculated once upon the first scroll and then never again. This means that when the size of an element changes (e.g., due to a browser resize or images being loaded) those coordinates become incorrect. It isn't an ideal solution to re-calulate the coordinates of every element on every scroll, but it will work until we can figure out a good API to trigger a re-calculation from outside the plugin.
