### PR TITLE
Feature/update to partially support hashes

### DIFF
--- a/modules/components/Element.js
+++ b/modules/components/Element.js
@@ -12,8 +12,9 @@ var Element = React.createClass({
      */
 
     var className = this.props.className || "";
-    
+
     var props = assign({}, this.props, {
+      id: this.props.name,
       className: this.props.className
     });
 

--- a/modules/mixins/Helpers.js
+++ b/modules/mixins/Helpers.js
@@ -106,6 +106,9 @@ var Helpers = {
     componentDidMount: function() {
       var domNode = this.getDOMNode ? this.getDOMNode() : ReactDOM.findDOMNode(this);
       scroller.register(this.props.name, domNode);
+      if (window.location.hash.substring(1) === this.props.name) {
+        scroller.scrollTo(this.props.name);
+      }
     },
     componentWillUnmount: function() {
       scroller.unregister(this.props.name);

--- a/modules/mixins/animate-scroll.js
+++ b/modules/mixins/animate-scroll.js
@@ -38,6 +38,7 @@ var __targetPositionY   = 0;
 var __progress          = 0;
 var __duration          = 0;
 var __cancel            = false;
+var __destinationHash   = false;
 
 var __start;
 var __deltaTop;
@@ -71,6 +72,8 @@ var animateTopScroll = function(timestamp) {
 
   if(__percent < 1) {
     requestAnimationFrame(animateTopScroll);
+  } else if (__destinationHash){
+    window.location.hash = __destinationHash;
   }
 
 };
@@ -81,6 +84,7 @@ var startAnimateTopScroll = function(y, options) {
   __startPositionY  = currentPositionY();
   __targetPositionY = y + __startPositionY;
   __duration        = options.duration || 1000;
+  __destinationHash = options.destinationHash || false;
 
   requestAnimationFrame(animateTopScroll);
 };

--- a/modules/mixins/scroller.js
+++ b/modules/mixins/scroller.js
@@ -59,7 +59,8 @@ module.exports = {
        */
 
       var options = {
-        duration : duration
+        duration : duration,
+        destinationHash : to
       };
 
       animateScroll.animateTopScroll(coordinates.top + (offset || 0), options);


### PR DESCRIPTION
Update react-scroll to support hashes. This will cause animated scroll links to set the url hash to the link's 'to' prop upon completion, and will automatically scroll to the element that matches the url's current hash string, if found, upon mounting said element.
