### PR TITLE
Replace hash support with deferred scrolling mixin

### DIFF
--- a/modules/components/Element.js
+++ b/modules/components/Element.js
@@ -14,7 +14,6 @@ var Element = React.createClass({
     var className = this.props.className || "";
 
     var props = assign({}, this.props, {
-      id: this.props.name,
       className: this.props.className
     });
 

--- a/modules/mixins/Helpers.js
+++ b/modules/mixins/Helpers.js
@@ -6,6 +6,8 @@ var animateScroll = require('./animate-scroll');
 var scrollSpy = require('./scroll-spy');
 var scroller = require('./scroller');
 
+var __deferredScrollDestination = '';
+
 var Helpers = {
 
   Scroll: {
@@ -105,8 +107,9 @@ var Helpers = {
     componentDidMount: function() {
       var domNode = this.getDOMNode ? this.getDOMNode() : ReactDOM.findDOMNode(this);
       scroller.register(this.props.name, domNode);
-      if (window.location.hash.substring(1) === this.props.name) {
+      if (__deferredScrollDestination === this.props.name) {
         scroller.scrollTo(this.props.name);
+        __deferredScrollDestination = '';
       }
     },
     componentWillUnmount: function() {

--- a/modules/mixins/animate-scroll.js
+++ b/modules/mixins/animate-scroll.js
@@ -38,7 +38,6 @@ var __targetPositionY   = 0;
 var __progress          = 0;
 var __duration          = 0;
 var __cancel            = false;
-var __destinationHash   = false;
 
 var __start;
 var __deltaTop;
@@ -72,8 +71,6 @@ var animateTopScroll = function(timestamp) {
 
   if(__percent < 1) {
     requestAnimationFrame(animateTopScroll);
-  } else if (__destinationHash){
-    window.location.hash = __destinationHash;
   }
 
 };
@@ -84,7 +81,6 @@ var startAnimateTopScroll = function(y, options) {
   __startPositionY  = currentPositionY();
   __targetPositionY = y + __startPositionY;
   __duration        = options.duration || 1000;
-  __destinationHash = options.destinationHash || false;
 
   requestAnimationFrame(animateTopScroll);
 };

--- a/modules/mixins/scroller.js
+++ b/modules/mixins/scroller.js
@@ -59,8 +59,7 @@ module.exports = {
        */
 
       var options = {
-        duration : duration,
-        destinationHash : to
+        duration : duration
       };
 
       animateScroll.animateTopScroll(coordinates.top + (offset || 0), options);


### PR DESCRIPTION
It turns out that the combination of smooth scrolling, react router and hashes does not play well with the browser forward/back navigation. This branch reverts hash support in favor of a different option: a 'deferred scrolling' mixin, which records a scroll key and directs the scroller to scroll to it later when and if it mounts.
