### PR TITLE
round the div coordinate bounds because scroll position is rounded

### DIFF
--- a/modules/mixins/Helpers.js
+++ b/modules/mixins/Helpers.js
@@ -72,7 +72,7 @@ var Helpers = {
           }
 
           var cords = element.getBoundingClientRect();
-          elemTopBound = (cords.top + y);
+          elemTopBound = Math.round(cords.top + y);
           elemBottomBound = elemTopBound + cords.height;
           var offsetY = y - this.props.offset;
           var isInside = (offsetY >= elemTopBound && offsetY <= elemBottomBound);


### PR DESCRIPTION
A disparity between how scroll position is rounded while element div bounds are not rounded was making the link highlighting not work right in certain cases.
