### PR TITLE
use window.setTimeout to move the defferred scrolling call to the bottom of the call stack

### DIFF
--- a/modules/mixins/Helpers.js
+++ b/modules/mixins/Helpers.js
@@ -108,8 +108,10 @@ var Helpers = {
       var domNode = this.getDOMNode ? this.getDOMNode() : ReactDOM.findDOMNode(this);
       scroller.register(this.props.name, domNode);
       if (__deferredScrollDestination === this.props.name) {
-        scroller.scrollTo(this.props.name);
-        __deferredScrollDestination = '';
+        window.setTimeout(function(){
+            scroller.scrollTo(__deferredScrollDestination);
+            __deferredScrollDestination = '';
+        });
       }
     },
     componentWillUnmount: function() {


### PR DESCRIPTION
The scrolling behavior of react-router can interfere with deferred scroll by automatically scrolling to the top of the page as soon as the entire page is done mounting. This change updates the deferred scrolling function to use a setTimeout to place the deferred scrolling call at the bottom of the call stack, after any actions tied to the initial page render are resolved.
