### PR TITLE
Bugfix/call scroll update on element mount

### DIFF
--- a/modules/mixins/Helpers.js
+++ b/modules/mixins/Helpers.js
@@ -68,8 +68,12 @@ var Helpers = {
 
         scrollSpy.addSpyHandler((function(y) {
 
-          if(!element) {
+          if(! element) {
               element = scroller.get(to);
+          }
+
+          if (! element) {
+            return;
           }
 
           var cords = element.getBoundingClientRect();
@@ -114,6 +118,7 @@ var Helpers = {
             __deferredScrollOffset = 0;
         });
       }
+      scrollSpy.scrollHandler();
     },
     componentWillUnmount: function() {
       scroller.unregister(this.props.name);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@synapsestudios/react-scroll",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "description": "A scroll component for React.js",
   "main": "modules",
   "repository": {


### PR DESCRIPTION
This update allows the initial active scroll link to be set when the elements load asynchronously.
