### PR TITLE
Bugfix/highlight current link when not async loaded

### DIFF
--- a/modules/mixins/Helpers.js
+++ b/modules/mixins/Helpers.js
@@ -97,6 +97,10 @@ var Helpers = {
             scrollSpy.updateStates();
           }
         }).bind(this));
+
+        if (scroller.getActiveLink() === this.props.to) {
+          this.setState({ active : true });
+        }
       }
     },
     componentWillUnmount: function() {

--- a/modules/mixins/Helpers.js
+++ b/modules/mixins/Helpers.js
@@ -69,11 +69,11 @@ var Helpers = {
         scrollSpy.addSpyHandler((function(y) {
 
           if(! element) {
+            if (scroller.get(to)) {
               element = scroller.get(to);
-          }
-
-          if (! element) {
-            return;
+            } else {
+              return;
+            }
           }
 
           var cords = element.getBoundingClientRect();

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@synapsestudios/react-scroll",
-  "version": "0.4.1",
+  "version": "0.4.2",
   "description": "A scroll component for React.js",
   "main": "modules",
   "repository": {


### PR DESCRIPTION
Right now if a view is loaded and the active link hasn't changed, the link won't appear active until the active link changes and changes back. This checks whether a link is already active upon mounting.
